### PR TITLE
Add CSV export support

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Trash2 } from "lucide-react";
 import { PlusIcon, ArrowPathIcon, MagnifyingGlassIcon, EnvelopeIcon } from "@heroicons/react/24/solid";
 import { AnimatePresence, motion } from "framer-motion";
+import { downloadCSV } from "@/lib/export";
 
 interface Entry {
   id: number;
@@ -196,6 +197,13 @@ export default function Home() {
               >
                 <ArrowPathIcon className="w-4 h-4" />
                 <span className="sr-only">Reset Entries</span>
+              </Button>
+              <Button
+                onClick={() => downloadCSV(entries)}
+                title="Export all entries to CSV"
+                className="bg-gray-100 text-gray-500 hover:bg-gray-200 focus:ring-2 focus:ring-gray-300"
+              >
+                Export CSV
               </Button>
             </div>
           </div>

--- a/lib/export.test.ts
+++ b/lib/export.test.ts
@@ -1,0 +1,13 @@
+import { entriesToCSV } from './export'
+
+describe('entriesToCSV', () => {
+  it('converts entries to csv', () => {
+    const csv = entriesToCSV([
+      { name: 'a', email: 'b', notes: 'c', tags: 't', next_steps: 'n' },
+      { name: 'x', email: 'y', notes: 'z' },
+    ])
+    expect(csv).toBe(
+      'name,email,notes,tags,next_steps\n"a","b","c","t","n"\n"x","y","z","",""'
+    )
+  })
+})

--- a/lib/export.ts
+++ b/lib/export.ts
@@ -1,0 +1,31 @@
+export interface CsvEntry {
+  name: string
+  email: string
+  notes: string
+  tags?: string
+  next_steps?: string
+}
+
+export function entriesToCSV(entries: CsvEntry[]): string {
+  const headers = ["name", "email", "notes", "tags", "next_steps"]
+  const rows = entries.map((e) =>
+    headers
+      .map((h) => {
+        const value = (e as Record<string, unknown>)[h] ?? ""
+        return `"${String(value).replace(/"/g, '""')}"`
+      })
+      .join(",")
+  )
+  return [headers.join(","), ...rows].join("\n")
+}
+
+export function downloadCSV(entries: CsvEntry[], filename = "customers.csv") {
+  const csv = entriesToCSV(entries)
+  const blob = new Blob([csv], { type: "text/csv" })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement("a")
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}


### PR DESCRIPTION
## Summary
- create CSV export helpers
- add export button to customer list
- test conversion helper

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_687852b313e48326acaf09b78f4dae93